### PR TITLE
infra: App Service IP restrictions + Cosmos DB firewall

### DIFF
--- a/docs/ip-restrictions.md
+++ b/docs/ip-restrictions.md
@@ -13,7 +13,7 @@ Run **after** the App Services are deployed (PR #19 merged and deploy workflows 
 | `embed-match-frontend` (frontend App Service) | IP allowlist — only team members |
 | `embed-db` (Cosmos DB) | Whitelist all **possible** outbound IPs of the backend App Service |
 
-> ⚠️ **Important**: Use `possibleOutboundIpAddresses` (up to ~20 IPs), NOT just  
+> ⚠️ **Important**: Use `possibleOutboundIpAddresses` (up to ~20 IPs), NOT just
 > `outboundIpAddresses` (4-5 IPs). Under load Azure may use any of the "possible" ones,
 > and Cosmos DB will reject requests from any unwhitelisted IP.
 
@@ -73,7 +73,7 @@ done
 
 ## Step 2 — Whitelist Backend Outbound IPs on Cosmos DB
 
-The backend App Service has a pool of possible outbound IPs that Azure may use. 
+The backend App Service has a pool of possible outbound IPs that Azure may use.
 You must whitelist **all** of them on Cosmos DB, not just the ones shown at a point in time.
 
 ### Get all possible outbound IPs


### PR DESCRIPTION
## Summary

Closes #9.

Adds step-by-step guide and `az` CLI scripts for locking down access to both App Services and the Cosmos DB account.

## What's included

`docs/ip-restrictions.md` contains:

- **Portal steps** for adding IP allowlists on `embed-match-web` and `embed-match-frontend`
- **Azure CLI scripts** to automate adding team member IPs to both App Services
- **Cosmos DB bulk firewall script** that fetches `possibleOutboundIpAddresses` (not just `outboundIpAddresses`) and applies them all in one `az cosmosdb update` call
- **Verification commands** to confirm the rules are applied
- **Local dev warning** — documents that team members must keep their own IP in the Cosmos DB firewall while developing locally

## Key design decision

> Uses `possibleOutboundIpAddresses` instead of `outboundIpAddresses` as specified in the issue. Azure may route outbound traffic from any IP in the possible list under load, so only whitelisting the current outbound IPs would cause intermittent 401s from Cosmos.

## When to apply

Run these scripts **after** PR #19 (deploy workflows) is merged and the App Services have been deployed at least once. The `az webapp show` command needs the App Service to exist to return its outbound IPs.

## Testing

After applying, verify with:
```bash
curl https://embed-match-web.azurewebsites.net/health
```
Should return `{"status": "healthy"}` from a whitelisted IP and a connection error from any other IP.